### PR TITLE
fix(module:RightContent): remove from pro-components

### DIFF
--- a/.template.config/templates/server/Layouts/BasicLayout.razor
+++ b/.template.config/templates/server/Layouts/BasicLayout.razor
@@ -5,7 +5,7 @@
     Logo="@("https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg")"
     MenuData="_menuData">
     <RightContentRender>
-        <RightContent />
+        <AntDesign.Pro.Template.Components.RightContent />
     </RightContentRender>
     <ChildContent>
         @Body

--- a/.template.config/templates/wasm/Layouts/BasicLayout.razor
+++ b/.template.config/templates/wasm/Layouts/BasicLayout.razor
@@ -5,7 +5,7 @@
     Logo="@("https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg")"
     MenuData="_menuData">
     <RightContentRender>
-        <RightContent />
+        <AntDesign.Pro.Template.Components.RightContent />
     </RightContentRender>
     <ChildContent>
         @Body


### PR DESCRIPTION
This PR is in direct connection to [PR18 in pro-components](https://github.com/ant-design-blazor/pro-components/pull/18). `RightContent` was removed from pro-components. It is still in the ant-design-pro-blazor as a part of the template. 

When testing this PR, the nuget package to ProLayout has to be replaced with the version that will contain changes proposed in aforementioned [PR18 in pro-components](https://github.com/ant-design-blazor/pro-components/pull/18). 

I tested templates with --full option:
* wasm
* server
* hosted
All of them started successfully.

Also during test I had to fully qualify the `Tooltip` because it was giving me compiler errors. I have not committed it here, because it is already a part of PR #68.