### PR TITLE
Update deprecated `dotnet watch -p` command in package.json script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "An out-of-box UI solution for enterprise applications as a Blazor boilerplate.",
     "scripts": {
-        "start": "dotnet watch -p ./src/AntDesign.Pro run",
+        "start": "dotnet watch --project ./src/AntDesign.Pro run",
         "build": "dotnet publish -o dist",
         "gulp:pro": "gulp --gulpfile ./src/AntDesign.Pro/gulpfile.js",
         "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
If not updated, the following warning is shown:

> dotnet watch ⌚ Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.