### PR TITLE
chore: exclude package.json and package-lock.json from compilation output

### DIFF
--- a/.template.config/templates/hosted/src/Client/AntDesign.Pro.Template.Client.csproj
+++ b/.template.config/templates/hosted/src/Client/AntDesign.Pro.Template.Client.csproj
@@ -32,5 +32,10 @@
     <Exec WorkingDirectory="$(SolutionDir)" Command="npm install" />
     <Exec WorkingDirectory="$(SolutionDir)" Command="npm run gulp:pro" />
   </Target>
+
+  <ItemGroup>
+    <Content Remove="package.json" />
+    <Content Remove="package-lock.json" />
+  </ItemGroup>
   <!--#endif -->
 </Project>

--- a/.template.config/templates/server/AntDesign.Pro.Template.csproj
+++ b/.template.config/templates/server/AntDesign.Pro.Template.csproj
@@ -29,5 +29,10 @@
     <Exec WorkingDirectory="$(SolutionDir)" Command="npm install" />
     <Exec WorkingDirectory="$(SolutionDir)" Command="npm run gulp:pro" />
   </Target>
+
+  <ItemGroup>
+    <Content Remove="package.json" />
+    <Content Remove="package-lock.json" />
+  </ItemGroup>
   <!--#endif -->
 </Project>

--- a/.template.config/templates/wasm/AntDesign.Pro.Template.csproj
+++ b/.template.config/templates/wasm/AntDesign.Pro.Template.csproj
@@ -33,5 +33,10 @@
     <Exec WorkingDirectory="$(SolutionDir)" Command="npm install" />
     <Exec WorkingDirectory="$(SolutionDir)" Command="npm run gulp:pro" />
   </Target>
+
+  <ItemGroup>
+    <Content Remove="package.json" />
+    <Content Remove="package-lock.json" />
+  </ItemGroup>
   <!--#endif -->
 </Project>


### PR DESCRIPTION
Closes #127.

_package.json_ and _package-lock.json_ files are copied to the output (`bin/Debug/net6/`) directory when `npm run start` is executed. They are also copied to the `dist/` directory when `npm run build` is executed. These files are only needed by a developer to run the npm-scripts, therefore there's no need for them to be copied to the output directory.